### PR TITLE
Fix valid fonts check and SendAsync()

### DIFF
--- a/Framework/ServiceClasses/PrinterServiceProvider/Handlers/PrintFormHandler.cs
+++ b/Framework/ServiceClasses/PrinterServiceProvider/Handlers/PrintFormHandler.cs
@@ -953,15 +953,19 @@ namespace XFS4IoTFramework.Printer
                                                $"COLOR is not valid.",
                                                PrintFormCompletion.PayloadData.ErrorCodeEnum.FieldError);
             }
-            
+
             // Check FONT
-            if (rules.ValidFonts != "ALL")
+
+            if (field.Type == FieldTypeEnum.TEXT)
             {
-                if (!rules.ValidFonts.Contains(field.Font))
+                if (rules.ValidFonts != "ALL")
                 {
-                    return new PrintFormResult(MessagePayload.CompletionCodeEnum.CommandErrorCode,
-                                               $"FONT is not valid.",
-                                               PrintFormCompletion.PayloadData.ErrorCodeEnum.FieldError);
+                    if (!rules.ValidFonts.Contains(field.Font, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new PrintFormResult(MessagePayload.CompletionCodeEnum.CommandErrorCode,
+                                                   $"FONT is not valid.",
+                                                   PrintFormCompletion.PayloadData.ErrorCodeEnum.FieldError);
+                    }
                 }
             }
 


### PR DESCRIPTION
Hello again, 
This was very difficult to replicate to me, so I can't help you. I had random websocket disconnections (abort) only if I compile in release mode.
this is my naive (but working) fix.

Please see:

https://learn.microsoft.com/en-us/dotnet/api/system.net.websockets.websocket.sendasync?view=net-6.0

**Exactly one send and one receive is supported on each object in parallel.**