### PR TITLE
Fix bug: Command not dequeue to handle

### DIFF
--- a/Framework/Server/CommandQueue.cs
+++ b/Framework/Server/CommandQueue.cs
@@ -226,9 +226,9 @@ namespace XFS4IoTServer
                 lock (WaitingTaskCompletionSources)
                 {
                     token.ThrowIfCancellationRequested();
-                    if (Signaled)
+                    if (Signaled > 0)
                     {
-                        Signaled = false;
+                        Signaled--;
                         return;
                     }
                     else
@@ -243,10 +243,13 @@ namespace XFS4IoTServer
                 TaskCompletionSource<bool> sourceToSignal = null;
                 lock (WaitingTaskCompletionSources)
                 {
+
                     if (WaitingTaskCompletionSources.Count > 0)
                         sourceToSignal = WaitingTaskCompletionSources.Dequeue();
-                    else if (!Signaled)
-                        Signaled = true;
+                    else
+                    {
+                        Signaled++;
+                    }
                 }
                 if (sourceToSignal != null)
                     sourceToSignal.SetResult(true);
@@ -254,7 +257,7 @@ namespace XFS4IoTServer
 
             private readonly static Task CompletedTask = Task.FromResult(true);
             private readonly Queue<TaskCompletionSource<bool>> WaitingTaskCompletionSources = new Queue<TaskCompletionSource<bool>>();
-            private bool Signaled;
+            private int Signaled;
         }
     }
 }


### PR DESCRIPTION
- Change Signaled to int type to count of command in list.

If use bool, the next command will never handle if haven't more command pushed to queue. 
Ex: First, 3 command push to queue, and "Signaled" will be true. 
    Then, "Command handler" will handle first command and set "Signaled" to false.
    After that, Next waiting of "Command handle" will don't process 2 remaining command and go to "await state" for next command.